### PR TITLE
Add AttributeError to except ImportError statements

### DIFF
--- a/dissect/evidence/tools/asdf/dd.py
+++ b/dissect/evidence/tools/asdf/dd.py
@@ -9,7 +9,7 @@ try:
     from tqdm import tqdm
 
     HAS_TQDM = True
-except ImportError:
+except (AttributeError, ImportError):
     HAS_TQDM = False
 
 


### PR DESCRIPTION
In some cases windows throws an AttributeError instead of an ImportError during an import