### PR TITLE
Improve exception when reading out of bounds

### DIFF
--- a/dissect/evidence/ewf.py
+++ b/dissect/evidence/ewf.py
@@ -232,7 +232,7 @@ class EWFStream(AlignedStream):
         while sector_count > 0:
 
             if segment_idx > len(self.ewf._segment_offsets):
-                raise EWFError(f"Reading missing EWF file for idx: {segment_idx}")
+                raise EWFError(f"Missing EWF file for segment index: {segment_idx}")
 
             segment = self.ewf.open_segment(segment_idx)
 

--- a/dissect/evidence/ewf.py
+++ b/dissect/evidence/ewf.py
@@ -230,7 +230,6 @@ class EWFStream(AlignedStream):
         segment_idx = bisect_right(self.ewf._segment_offsets, sector_offset)
 
         while sector_count > 0:
-
             if segment_idx > len(self.ewf._segment_offsets):
                 raise EWFError(f"Missing EWF file for segment index: {segment_idx}")
 

--- a/dissect/evidence/ewf.py
+++ b/dissect/evidence/ewf.py
@@ -228,7 +228,12 @@ class EWFStream(AlignedStream):
         sector_count = (length + self.sector_size - 1) // self.sector_size
 
         segment_idx = bisect_right(self.ewf._segment_offsets, sector_offset)
+
         while sector_count > 0:
+
+            if segment_idx > len(self.ewf._segment_offsets):
+                raise EWFError(f"Reading missing EWF file for idx: {segment_idx}")
+
             segment = self.ewf.open_segment(segment_idx)
 
             segment_remaining_sectors = segment.sector_count - (sector_offset - segment.sector_offset)


### PR DESCRIPTION
This PR adds an explicit exception when dealing with incomplete EnCase/EWF streams. This can occur when you have a (partially) corrupt E01 file or if you are missing an EnCase file in a series of split EnCase files.

We now raise an exception when trying to read a segment that is not available. 

Previously you would be greeted with the following, which can be challenging to debug when encountered for the first time.
```
... File /tmp/dissect/evidence/ewf.py line 192 in open_segment
    fh = self.fh[idx]
IndexError: list index out of range
```

This is now improved with a specific `EWFError` and can be handled better by parent implementations such as `dissect.target`.