### PR TITLE
Add find_files to EWF module exports

### DIFF
--- a/dissect/evidence/ewf/__init__.py
+++ b/dissect/evidence/ewf/__init__.py
@@ -10,6 +10,7 @@ from dissect.evidence.ewf.ewf import (
     Segment,
     TableSection,
     VolumeSection,
+    find_files,
 )
 
 __all__ = [
@@ -22,4 +23,5 @@ __all__ = [
     "TableSection",
     "VolumeSection",
     "c_ewf",
+    "find_files",
 ]


### PR DESCRIPTION
Small oversight in #39 causes some import errors for other projects (e.g. target).