### PR TITLE
Increase Cache size with environment variable

### DIFF
--- a/dissect/evidence/aff4/stream.py
+++ b/dissect/evidence/aff4/stream.py
@@ -1,5 +1,6 @@
 from __future__ import annotations
 
+import os
 import struct
 import zlib
 from bisect import bisect_right
@@ -13,6 +14,9 @@ from dissect.evidence.aff4.util import NS_AFF4, CompressionMethod
 
 if TYPE_CHECKING:
     from dissect.evidence.aff4.metadata import ImageStream, Information, Map
+
+CHUNK_CACHE_SIZE = int(os.getenv("DISSECT_AFF4_CHUNK_CACHE_SIZE", 512))
+BEVY_CACHE_SIZE = int(os.getenv("DISSECT_AFF4_BEVY_CACHE_SIZE", 8))
 
 
 def _open_stream(ctx: Information, id: str) -> BinaryIO:
@@ -105,8 +109,8 @@ class BevyStream(AlignedStream):
 
         self.compression_method = self.stream.compression_method
 
-        self._open_bevy = lru_cache(maxsize=8)(self._open_bevy)
-        self._read_chunk = lru_cache(maxsize=512)(self._read_chunk)
+        self._open_bevy = lru_cache(maxsize=BEVY_CACHE_SIZE)(self._open_bevy)
+        self._read_chunk = lru_cache(maxsize=CHUNK_CACHE_SIZE)(self._read_chunk)
 
         super().__init__(self.stream.size, self.stream.chunk_size)
 
@@ -124,7 +128,7 @@ class BevyStream(AlignedStream):
 
         return bevy_path.open("rb"), index
 
-    def _read_chunk(self, bevy_idx: int, chunk_idx: int) -> bytes:
+    def _read_chunk(self, chunk_idx: int) -> bytes:
         bevy_idx = chunk_idx // self.stream.chunks_in_segment
         bevy_fh, index = self._open_bevy(bevy_idx)
 
@@ -155,7 +159,7 @@ class BevyStream(AlignedStream):
         chunk_idx, offset_in_chunk = divmod(offset, self.stream.chunk_size)
 
         while length > 0:
-            chunk = self._read_chunk(chunk_idx, chunk_idx)
+            chunk = self._read_chunk(chunk_idx)
             read_size = min(length, self.stream.chunk_size - offset_in_chunk)
 
             result.append(chunk[offset_in_chunk : offset_in_chunk + read_size])

--- a/dissect/evidence/aff4/stream.py
+++ b/dissect/evidence/aff4/stream.py
@@ -15,7 +15,7 @@ from dissect.evidence.aff4.util import NS_AFF4, CompressionMethod
 if TYPE_CHECKING:
     from dissect.evidence.aff4.metadata import ImageStream, Information, Map
 
-CHUNK_CACHE_SIZE = int(os.getenv("DISSECT_AFF4_CHUNK_CACHE_SIZE", 512))
+CHUNK_CACHE_SIZE = int(os.getenv("DISSECT_AFF4_CHUNK_CACHE_SIZE", 32 * 1024))
 BEVY_CACHE_SIZE = int(os.getenv("DISSECT_AFF4_BEVY_CACHE_SIZE", 8))
 
 


### PR DESCRIPTION
When experimenting with a compressed disk + `walkfs` I've noticed pretty noticeable speedups by increasing the cache size at the cost of memory. 

The culprit seems to be because 94% of the time is spend on decryption (see below), this is the result of the fact that the tree in this specific example doesn't fit the cache and is discarded and decompressed over and over again.

Estimated gains by increasing the cache size to various sizes (for 1 specific folder with `walkfs` that has 7,700 entries)
```
RESULT  cache_size | decompressions | est_native_time
RESULT         512 |         268447 | 3221s (53.7 min)
RESULT        4096 |         213218 | 2559s (42.6 min)
RESULT        8192 |         128281 | 1539s (25.7 min)
RESULT       16384 |          42960 | 516s (8.6 min)
RESULT       32768 |          21952 | 263s (4.4 min)
RESULT       65536 |          21952 | 263s (4.4 min)
RESULT      131072 |          21952 | 263s (4.4 min)
RESULT   unbounded |          21952 | 263s (4.4 min)
```

I've tested this and with a cache_size of 32768 indeed the process now takes around 1.25GB and completes in 4m40s seconds instead of 52m04s.

This might be handy if you're not concerned about going out of memory of just want to perform a single function as fast as possible. I set the defaults to the same values that were already there so it doesn't change the default behavior. 

Additional testing I found the following results (inspecting terminal execution time + Activity Monitor)
```
cache_size | system memory | time
512        | ~1.25GB       | 52m04s
8192       | ~960MB        | 24m59s
32768      | ~480MB        | 4m40s
```
Seems that impact from significantly increasing the cache is

We could definitely consider bumping the cache size to `8192` for a balanced tradeoff between memory and CPU. I think in general the `dissect` framework's bottleneck is CPU / IO and not memory. 1CPU + ~1GB seems reasonable.

I ran everything an additional time with the `time -l` command:

<table>
  <tr>
    <th>32768</th>
    <th>8192</th>
    <th>512 (default)</th>
  </tr>
  <tr>
    <td>
<pre><code>
      299.47 real       291.13 user         4.95 sys
          1293910016  maximum resident set size
                   0  average shared memory size
                   0  average unshared data size
                   0  average unshared stack size
              386284  page reclaims
                 741  page faults
                   0  swaps
                   0  block input operations
                   0  block output operations
                   0  messages sent
                   0  messages received
                   0  signals received
                2668  voluntary context switches
               80977  involuntary context switches
       5268870312607  instructions retired
       1097380957230  cycles elapsed
          1652361208  peak memory footprint
</code></pre>
    </td>
    <td>
<pre><code>
     1499.73 real      1474.47 user        21.23 sys
           892993536  maximum resident set size
                   0  average shared memory size
                   0  average unshared data size
                   0  average unshared stack size
              388334  page reclaims
                 105  page faults
                   0  swaps
                   0  block input operations
                   0  block output operations
                   0  messages sent
                   0  messages received
                   0  signals received
                1685  voluntary context switches
              283928  involuntary context switches
      30043480123739  instructions retired
       5863335625386  cycles elapsed
          1075086776  peak memory footprint
</code></pre>
    </td>
    <td>
<pre><code>
     3083.96 real      3036.83 user        41.79 sys
           487456768  maximum resident set size
                   0  average shared memory size
                   0  average unshared data size
                   0  average unshared stack size
              311740  page reclaims
                  47  page faults
                   0  swaps
                   0  block input operations
                   0  block output operations
                   0  messages sent
                   0  messages received
                   0  signals received
                1545  voluntary context switches
              415892  involuntary context switches
      62912393219997  instructions retired
      12280092958300  cycles elapsed
           511558712  peak memory footprint
</code></pre>
    </td>
  </tr>
</table>

## Profiling info:
<img width="1047" height="5264" alt="spotlight" src="https://github.com/user-attachments/assets/41012df0-0174-4d98-ad06-a85d83aa47f8" />
